### PR TITLE
Add profiles for docker and nextflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # TB-Predict-Pipeline
 Nextflow pipeline for producing variants, mutations and effects of a specified (minos) VCF file
+
+## Run locally with Docker
+```
+nextflow run . -profile docker --sample <absolute sample path> --reference <absolute reference path> --catalogue <absolute catalogue path> --output_dir <absolute output directory path>
+```
+Note that the output directory must exist. The python script aims to create the directory, but as nextflow symbolic links to the given path, and works from the `work` folder, the highest level directory of the path is symlinked to the actual path. This makes it impossible to access the actual path from the python script...
+
+## Run with Kubernetes
+This does not currently work due to unknown issues with Nextflow and Kubernetes...
+```
+nextflow run . -profile kubernetes --sample <absolute sample path> --reference <absolute reference path> --catalogue <absolute catalogue path> --output_dir <absolute output directory path>
+```

--- a/main.nf
+++ b/main.nf
@@ -31,6 +31,8 @@ Mandatory parameters:
 --reference         Path to the reference genome's genbank file, or a pickle dump of the corresponding gumpy Genome
 --catalogue         Path to the resistance catalogue
 --output_dir        Desired output path for all files produced by gnomon
+--fasta             The kind of fasta file to generate. Defaults to fixed length (indels do not change length).
+                    One of `fixed` and `variable`
 """
 .stripIndent()
 }
@@ -46,6 +48,7 @@ Parameters used:
 --reference         ${params.reference}
 --catalogue         ${params.catalogue}
 --output_dir        ${params.output_dir}
+--fasta             ${params.fasta}
 
 Runtime data:
 ------------------------------------------------------------------------
@@ -62,18 +65,27 @@ process runPrediction {
         path reference
         path catalogue
         path outputDir
+        val fasta
     output:
         path "$outputDir/gnomon.log"
         path "$outputDir/variants.csv"
+        path "$outputDir/gnomon-out.json" //Always create the JSON
         path "$outputDir/mutations.csv" optional true
         path "$outputDir/effects.csv" optional true
+        //One of these will always be created. Default is fixed length
+        path "$outputDir/*-fixed.fasta" optional true
+        path "$outputDir/*-variable.fasta" optional true
     script:
+        //This is an admittedly hacky way to try to get it to run inside docker
+        //But should only be used for testing
         """
-        gnomon --genome_object $reference --catalogue $catalogue --vcf_file $sample --output_dir $outputDir --filetype csv
+        apt update && apt install -y python3-pip git
+        git clone https://github.com/oxfordmmm/gnomon && cd gnomon && pip install .
+        gnomon --genome_object $reference --catalogue $catalogue --vcf_file $sample --output_dir $outputDir --json --fasta $fasta
         """
 }
 
 workflow {
     main:
-        runPrediction(params.sample, params.reference, params.catalogue, params.output_dir)
+        runPrediction(params.sample, params.reference, params.catalogue, params.output_dir, params.fasta)
 }

--- a/main.nf
+++ b/main.nf
@@ -79,8 +79,9 @@ process runPrediction {
         //This is an admittedly hacky way to try to get it to run inside docker
         //But should only be used for testing
         """
-        apt update && apt install -y python3-pip git
+        apt-get update && apt-get install -y python3-pip git
         git clone https://github.com/oxfordmmm/gnomon && cd gnomon && pip install .
+        cd ..
         gnomon --genome_object $reference --catalogue $catalogue --vcf_file $sample --output_dir $outputDir --json --fasta $fasta
         """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -3,7 +3,7 @@ params {
     fasta = 'fixed'
 }
 profiles {
-    docker {
+    kubernetes {
         k8s {
             namespace = 'default'
             storageClaimName = 'default-nextflow-fss-storage-work-pvc'
@@ -21,5 +21,13 @@ profiles {
         docker.enabled = true
         process.executor = 'k8s'
         process.container = 'ubuntu:20.04'
+    }
+    docker {
+        docker.enabled = true
+        fixOwnership = true
+        runOptions = "-u \$(id -u):\$(id -g)"
+        process.cpus = 4
+        process.memory = "4GB"
+        process.container = "ubuntu:latest"
     }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,5 +1,6 @@
 params {
     help = ''
+    fasta = 'fixed'
 }
 profiles {
     docker {

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,0 +1,24 @@
+params {
+    help = ''
+}
+profiles {
+    docker {
+        k8s {
+            namespace = 'default'
+            storageClaimName = 'default-nextflow-fss-storage-work-pvc'
+            storageMountPath = '/work'
+            launchDir = "/work/runs/${params.sample}"
+
+            serviceAccount = 'default'
+            projectDir = '/work/project'
+            pod = [
+                [label: 'pod-type', value: 'nextflow-worker'],
+                [volumeClaim: 'default-nextflow-fss-storage-data-pvc', mountPath: '/data'],
+                [imagePullPolicy: 'IfNotPresent']
+            ]
+        }
+        docker.enabled = true
+        process.executor = 'k8s'
+        process.container = 'ubuntu:20.04'
+    }
+}


### PR DESCRIPTION
Add profiles for docker and nextflow. Updated readme. Currently works with local Docker containers (with profile `docker`), but not using Kubernetes (with profile `kubernetes`)